### PR TITLE
fix(Errores): :rotating_light: Correcion estaba causando el error de …

### DIFF
--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -1,13 +1,12 @@
+// components/ui/input.tsx
+
 "use client";
 
 import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface InputProps
-  extends React.InputHTMLAttributes<HTMLInputElement> {}
-
-const Input = React.forwardRef<HTMLInputElement, InputProps>(
+const Input = React.forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLInputElement>>(
   ({ className, type, ...props }, ref) => {
     return (
       <input


### PR DESCRIPTION
This pull request includes a small change to the `components/ui/input.tsx` file. The change simplifies the `Input` component by removing the `InputProps` interface and directly using `React.InputHTMLAttributes<HTMLInputElement>` in the `React.forwardRef` call.

* [`components/ui/input.tsx`](diffhunk://#diff-c2f62fb0cb5e2955363d1c27d9cb0b33d03fed2193d16c3877af492d82770d2cR1-R9): Removed the `InputProps` interface and directly used `React.InputHTMLAttributes<HTMLInputElement>` in the `React.forwardRef` call.